### PR TITLE
Add async client cleanup and shutdown handling

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -27,6 +27,13 @@ class ResonanceAgent:
         self.user_profile = UserProfile(user_id=user_id)
         print(f"🤖 Resonance Agent '{self.user_id}' üçün hazır vəziyyətdədir.")
 
+    async def close(self) -> None:
+        """Agentin daxili resurslarını azad edir."""
+        if hasattr(self.nlp_engine, "close"):
+            await self.nlp_engine.close()
+        if hasattr(self.response_generator, "close"):
+            await self.response_generator.close()
+
     async def process_message(self, text: str) -> Dict[str, Any]:
         """İstifadəçi mesajını tamamilə emal edir və cavab qaytarır."""
         print("\n" + "-"*50)

--- a/main.py
+++ b/main.py
@@ -80,6 +80,7 @@ async def run_cli_mode(agent: ResonanceAgent):
         except (KeyboardInterrupt, EOFError):
             break
     print("\n👋 Agentlə dialoq bitdi. Sağ olun!")
+    await agent.close()
 
 
 # ---Əsas Giriş Nöqtəsi ---

--- a/nlp_engine.py
+++ b/nlp_engine.py
@@ -127,3 +127,13 @@ class LocalNLPEngine(NLPEngineProtocol):
         except Exception as e:
             print(f"❌ Lokal embedding yaradılmasında xəta: {e}")
             return np.zeros(self.embedding_size)
+
+    async def close(self) -> None:
+        """Async HTTP müştərisini bağlayır."""
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "LocalNLPEngine":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/response_generator.py
+++ b/response_generator.py
@@ -91,3 +91,14 @@ class LocalResponseGenerator(ResponseGeneratorProtocol):
             final_response = "I'm sorry, I encountered an error with the local model. Please check if it's running correctly."
 
         return {"text": final_response}
+
+    async def close(self) -> None:
+        """Async HTTP müştərisini bağlayır."""
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "LocalResponseGenerator":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+

--- a/web_server.py
+++ b/web_server.py
@@ -27,6 +27,8 @@ async def lifespan(app: FastAPI):
         agent_instance = None
     yield
     print("--- Veb Server Dayanır ---")
+    if agent_instance is not None:
+        await agent_instance.close()
 
 def get_agent() -> ResonanceAgent:
     """Agenti əldə etmək üçün FastAPI dependency funksiyası."""
@@ -82,3 +84,5 @@ async def get_status(agent: ResonanceAgent = Depends(get_agent)):
         "agent_initialized": True, # 'Depends' bunu təmin edir
         "engine_type": os.getenv("ENGINE_TYPE", "google").lower()
     }
+
+


### PR DESCRIPTION
## Summary
- add async close methods for local NLP engine and response generator
- expose `ResonanceAgent.close` to release subcomponents
- invoke cleanup during CLI exit and FastAPI shutdown

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f68df47288328bebb455d67161fcb